### PR TITLE
Update jquery.keynav.js

### DIFF
--- a/javascript/jquery.keynav.js
+++ b/javascript/jquery.keynav.js
@@ -16,6 +16,7 @@
 ;(function($, window, document, undefined) {
 
 	$.fn.keynav = function(checkNav) {
+		$(document).unbind(".keynav"); //unbind any other keynavs from the document
 		var elements = this;
 		var matrix;
 		var x;
@@ -97,7 +98,7 @@
 		});
 
 
-		$(document).keydown(function(e){
+		$(document).bind("keydown.keynav",function(e){
 			if (checkNav && checkNav()) return;
 			if (e.keyCode == 37) {
 				// left
@@ -116,7 +117,7 @@
 				setCurrent(x+1,y);
 				e.preventDefault();
 			} else if (e.keyCode == 13) {
-				window.location = current.attr('href');
+				current.mouseup(); //perform the mouseup event of the item
 				e.preventDefault();
 			}
 		});


### PR DESCRIPTION
Changed the $(document).keydown to a $(document).bind("keydown",...) with a namespace so that new instances of keynav on the same page do not interfere. This allows a dialog window to obtain a keynav without influence on the main page.

You do need to re-keynav the main page when the dialog is closed.
