### PR TITLE
Refactored and added lots of custom options & methods

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,7 +10,7 @@ a {
 
 pre {
 	background: #f0f0f0;
-	padding: 1em 1em 0;
+	padding: 0.5em 1em 0.5em;
 }
 code {
 	background: #f0f0f0;
@@ -78,3 +78,17 @@ pre code {
 * html .clearfix { height: 1%; }
 .clearfix { display: block; }
 /* close commented backslash hack */
+
+.table {
+	border: 1px solid #ccc;
+	width: 100%;
+}
+
+.table th {
+	text-align: left;
+	padding: 5px;
+}
+
+.table td {
+	padding: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -54,53 +54,95 @@
 		</li>
 	</ul>
 
-	<p>The rows should have the same vertical offset. You can mark one element with <code>.selected</code> class, or the first one will be selected.</p>
+	<p>The rows should have the same vertical offset. You can mark one element with <code>.selected</code> class, or the first one can be selected automatically.</p>
 
-	<p>Enter key replaces <code>window.location.href</code> with the current <code>href</code> value.</p>
+	<p>Pressing <code>ENTER</code> key navigates to the link in the current window.
 
-	<h2 id="usage:">Usage:</h2>
+	<h2 id="usage:">Basic Usage:</h2>
 
-	<pre><code>$('#navigation a').keynav();
-	</code></pre>
+	<pre><code>$('#navigation a').keynav();</code></pre>
 
-	<p>This will enable keyboard navigation for the links in <code>#navigation</code> container. If you need to have some control on the state of plugin you can pass the additional function as a single parameter:</p>
+	<p>This will enable keyboard navigation for the links in <code>#navigation</code> container.
 
-	<pre><code>$('#navigation a').keynav(function(){
-	        return window.keyNavigationDisabled;
-	});
-	</code></pre>
+	<h2 id="usage:">Advanced Usage:</h2>
 
-	<p>Note: If the function passed returns <code>true</code> - keyboard navigation stops.</p>
+	<pre><code>$('#navigation a').keynav({ autoSelectFirst: false });</code></pre>
 
-<script>
-	$(function(){
+	<p>Please see possible options you can pass below.</p>
 
-		updateControls = function() {
-			$('#navigation a').removeClass();
-			$((window.keyNavigationDisabled?'#disable':'#enable')).addClass('selected');
-		}
+	<h2>Options</h2>
 
-	  a=$('.nav_holder a').keynav(function() {
-	  		return window.keyNavigationDisabled;
-	  });
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th>Default</th>
+				<th>Comment</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>updateResizeInterval</td>
+				<td>500</td>
+				<td>Update the navigation matrix every 500ms when window is resized.</td>
+			</tr>
+			<tr>
+				<td>autoSelectFirst</td>
+				<td>true</td>
+				<td>Automatically select the first element (unless another element has <code>.selected</code> class)</td>
+			</tr>
+		</tbody>
+	</table>
 
-	  $('#disable').click(function(){
-	  	window.keyNavigationDisabled=true;
-	  	updateControls();
-	  });
+	<h2>API</h2>
 
-	  $('#enable').click(function(){
-			window.keyNavigationDisabled=false;
-			updateControls();
-	  });
+	<h3>$('a.links').keynav('update')</h3>
+	<p>Update the keynav matrix manually</p>
 
+	<h3>$('a.links').keynav('destroy')</h3>
+	<p>Destroy the keynav and revert items to original state.</p>
 
-	});
-</script>
+	<hr/>
 
-<a class="selected download" href="https://github.com/firedev/jquery.keynav/blob/master/javascript/jquery.keynav.js">Download from GitHub</a>
+	<a class="selected download" href="https://github.com/firedev/jquery.keynav/blob/master/javascript/jquery.keynav.js">Download from GitHub</a>
 
-<a href="https://github.com/firedev/jquery.keynav"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+	<a href="https://github.com/firedev/jquery.keynav"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+	<script>
+		(function() {
+
+			var keynavEnabled = false;
+			var updateControls = function() {
+				$('#navigation a').removeClass();
+				$(keynavEnabled ? '#enable' : '#disable').addClass('selected');
+			};
+
+			var $navLinks = $('.nav_holder a');
+
+			var initKeynav = function() {
+				$navLinks.keynav();
+				keynavEnabled = true;
+			};
+
+			var destroyKeynav = function() {
+				$navLinks.keynav('destroy');
+				keynavEnabled = false;
+			};
+
+			$('#disable').click(function() {
+				destroyKeynav();
+				updateControls();
+			});
+
+			$('#enable').click(function() {
+				initKeynav();
+				updateControls();
+			});
+
+			initKeynav();
+
+		})();
+	</script>
 
 </body>
 </html>

--- a/javascript/jquery.keynav.js
+++ b/javascript/jquery.keynav.js
@@ -15,55 +15,115 @@
 
 ;(function($, window, document, undefined) {
 
-	$.fn.keynav = function(checkNav) {
-		var elements = this;
-		var matrix;
-		var x;
-		var y;
-		var current = this.filter('.selected');
-		var keyNavigationDisabled=false;
-		if (current.length == 0) current = this.first();
 
-		current.addClass('selected');
+	function Keynav(elements, options) {
+	
+		// Bind main plugin events
+		this.bindEvents();
 
-		function update() {
-			var i=0;
-			var row = Array();
-			var j = -1;
-			var oldtop = false;
-			var m=Array();
+		// Initialize the keynav
+		this.init(elements, options);
+	}
 
-			elements.each(function(){
+	Keynav.prototype = {
+
+		init: function(elements, options) {
+
+			var defaults = {
+				updateResizeInterval: 500, // Update every 500ms when window is resized
+				autoSelectFirst: true,
+			};
+
+			// Set the options, merging any defaults
+			this.options = $.extend({}, defaults, options);
+
+			this.matrix = [],
+			this.x = 0,
+			this.y = 0;
+			this.elements = elements;
+
+			this.current = this.elements.filter('.selected');
+
+			if (this.current.length == 0 && this.options.autoSelectFirst)
+			{
+				this.selectFirst();
+			}
+
+			// Update the matrix
+			this.update();
+		},
+
+		bindEvents: function() {
+			this.bindKeyboard();
+			this.bindResize();
+		},
+
+		unbindEvents: function() {
+			this.unbindKeyboard();
+			this.unbindResize();
+		},
+
+		bindResize: function() {
+			$(window).on('resize', $.proxy(this.onResize, this));
+		},
+
+		unbindResize: function() {
+			$(window).off('resize', $.proxy(this.onResize, this));
+		},
+
+		bindKeyboard: function() {
+			$(document).on('keydown', $.proxy(this.onKeydown, this));
+		},
+
+		unbindKeyboard: function() {
+			$(document).off('keydown', $.proxy(this.onKeydown, this));
+		},
+
+		update: function() {
+
+			var i = 0,
+				row = [],
+				j = -1,
+				oldtop = false,
+				m = [];
+
+			this.elements.each(function() {
 				if (!oldtop) oldtop = this.offsetTop;
-				newtop=this.offsetTop;
-				if (newtop != oldtop) {
-					oldtop=newtop;
-					m[i]=row;
-					row = Array();
+				newtop = this.offsetTop;
+				if (newtop != oldtop)
+				{
+					oldtop = newtop;
+					m[i] = row;
+					row = [];
 					i++;
 					j=0;
-					row[j]=this;
-				} else {
+					row[j] = this;
+				}
+				else
+				{
 					j++;
-					row[j]=this;
+					row[j] = this;
 				}
 			});
-			m[i]=row;
-			matrix = m;
-			coordinates=findCurrent();
-			x=coordinates[0];
-			y=coordinates[1];
-			return matrix;
-		}
+			m[i] = row;
+			this.matrix = m;
+			coordinates = this.findCurrent();
+			this.x = coordinates[0];
+			this.y = coordinates[1];
+			return m;
+		},
 
-		function findCurrent() {
-			i=0; j=0; found = false;
+		findCurrent: function() {
+			var i = 0, j = 0, found = false;
 			try {
-				for (i=0; i<matrix.length; i++) {
-					row=matrix[i];
-					for (j=0; j<row.length; j++) {
-						if (current[0] == row[j]) {
-							throw([i,j]);
+				for (i=0; i < this.matrix.length; i++)
+				{
+					row = this.matrix[i];
+					for (j=0; j < row.length; j++)
+					{
+						if (this.current[0] == row[j])
+						{
+							return [i, j];
 						}
 
 					}
@@ -71,56 +131,122 @@
 			}
 			catch (arr)
 			{
-				found = [i,j]
+				// found = [-1, -1]
 			}
-			return(found);
-		}
 
-		function setCurrent(i,j) {
-			if (i<0) i=(matrix.length-1);
-			if (i>=matrix.length) i=0;
-			if (j<0) j=(matrix[i].length-1);
-			if (j>=matrix[i].length) j=0;
-			current.removeClass('selected');
-			current = $(matrix[i][j]);
-			current.addClass('selected');
-			x=i;
-			y=j;
-		}
+			return [-1, 0];
+		},
 
-		$(window).bind("resize", function(event) {
-			update();
-		});
+		setCurrent: function(i,j) {
 
-		$(document).ready(function() {
-			update();
-		});
+			var matrix = this.matrix;
+			if (i < 0) i = (matrix.length - 1);
+			if (i >= matrix.length) i = 0;
+			if (j < 0) j = (matrix[i].length - 1);
+			if (j >= matrix[i].length) j = 0;
+			this.current.removeClass('selected');
+			this.current = $(matrix[i][j]);
+			this.current.addClass('selected');
+			this.x = i;
+			this.y = j;
+		},
 
+		onResize: function() {
 
-		$(document).keydown(function(e){
-			if (checkNav && checkNav()) return;
-			if (e.keyCode == 37) {
+			if (this.resizeTimer)
+			{
+				clearTimeout(this.resizeTimer);
+			}
+
+			this.resizeTimer = setTimeout($.proxy(this.update, this), this.options.updateResizeInterval);
+		},
+
+		selectFirst: function() {
+			this.current = this.elements.first();
+			this.current.addClass('selected');
+			this.update();
+		},
+
+		onKeydown: function(e) {
+
+			var x = this.x, y = this.y;
+
+			if ($.inArray(e.keyCode, [37, 38, 39, 40, 13]) !== -1)
+			{
+				e.preventDefault();
+			}
+
+			switch (e.keyCode)
+			{
 				// left
-				setCurrent(x,y-1);
-				e.preventDefault();
-			} else if (e.keyCode == 38) {
-				// up
-				setCurrent(x-1,y);
-				e.preventDefault();
-			} else if (e.keyCode == 39) {
-				// right
-				setCurrent(x,y+1);
-				e.preventDefault();
-			} else if (e.keyCode == 40) {
-				// down
-				setCurrent(x+1,y);
-				e.preventDefault();
-			} else if (e.keyCode == 13) {
-				window.location = current.attr('href');
-				e.preventDefault();
-			}
-		});
+				case 37:
+					this.setCurrent(x,y-1);
+					break;
 
+				// up
+				case 38:
+					this.setCurrent(x-1,y);
+					break;
+
+				// right
+				case 39:
+					this.setCurrent(x,y+1);
+					break;
+
+				// down
+				case 40:
+					this.setCurrent(x+1,y);
+					break;
+
+				case 13:
+					if (this.current)
+					{
+						window.location = this.current.attr('href');
+					}
+					break;
+			}
+		},
+
+		destroy: function() {
+			this.unbindEvents();
+			this.current.removeClass('selected');
+		}
+
+	};
+
+	$.fn.keynav = function(options, value) {
+
+		// Initialize keynav?
+		var keynav = $.data(window, 'keynav');
+
+		if (keynav === undefined)
+		{
+			keynav = new Keynav(this, options);
+			$.data(window, 'keynav', keynav);
+		}
+		else
+		{
+			keynav.init(this, options);
+		}
+
+		// Handle method calls
+		if (typeof options === 'string')
+		{
+			switch (options)
+			{
+				case 'update':
+					keynav.update();
+					break;
+
+				case 'destroy':
+					keynav.destroy();
+					$.removeData(window, 'keynav');
+					break;
+
+			}
+
+			return;
+		}
 
 		return this;
 	}


### PR DESCRIPTION
This is a pretty big PR, possibly could have broken it down a bit more but decided just to go ahead with the full shabang!

Basically it refactors it to be more state-aware and add's the ability to call methods like `update` and `destroy` to destroy the plugin (replacing the function callback to decide if the plugin is enabled or not). For that reason it's not backwards compatible so would likely need a version bump.

It also adds the ability to not automatically select the first option on initialization and doesn't attempt to continously update whilst window is being resized, it'll do it every 500ms.

As I said, pretty big PR not even sure if this thing is maintained anymore but thought I'd send it your way anyway to see what you think. Docs have been updated too
